### PR TITLE
Jira 5.2で設定が保存できなくなっていたのを修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
+          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
     </plugins>
@@ -91,7 +92,7 @@
   </dependencies>
 
   <properties>
-    <jira.version>4.4.1</jira.version>
+    <jira.version>5.2</jira.version>
     <jira.data.version>4.4</jira.data.version>
     <amps.version>3.8</amps.version>
   </properties>

--- a/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfig.java
+++ b/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfig.java
@@ -18,6 +18,17 @@ public final class IrcBotGlobalConfig {
 	@XmlElement
 	private int ircServerPort;
 
+	@XmlElement
+	private String ircEncoding;
+	
+	public String getIrcEncoding() {
+		return ircEncoding;
+	}
+
+	public void setIrcEncoding(String ircEncoding) {
+		this.ircEncoding = ircEncoding;
+	}
+
 	public String getIrcServerName() {
 		return ircServerName;
 	}

--- a/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfigResource.java
+++ b/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfigResource.java
@@ -67,11 +67,11 @@ public class IrcBotGlobalConfigResource {
 						if (ircServerPort != null) {
 							config.setIrcServerPort(Integer
 									.parseInt(ircServerPort));
-							
-							config.setIrcEncoding((String) settings
-									.get(IrcBotGlobalConfig.class.getName()
-											+ ".ircEncoding"));
 						}
+						
+						config.setIrcEncoding((String) settings
+								.get(IrcBotGlobalConfig.class.getName()
+										+ ".ircEncoding"));
 						return config;
 					}
 				})).build();

--- a/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfigResource.java
+++ b/src/main/java/com/github/j5ik2o/jiraircbot/IrcBotGlobalConfigResource.java
@@ -67,6 +67,10 @@ public class IrcBotGlobalConfigResource {
 						if (ircServerPort != null) {
 							config.setIrcServerPort(Integer
 									.parseInt(ircServerPort));
+							
+							config.setIrcEncoding((String) settings
+									.get(IrcBotGlobalConfig.class.getName()
+											+ ".ircEncoding"));
 						}
 						return config;
 					}
@@ -96,6 +100,8 @@ public class IrcBotGlobalConfigResource {
 				pluginSettings.put(IrcBotGlobalConfig.class.getName()
 						+ ".ircServerPort",
 						Integer.toString(config.getIrcServerPort()));
+				pluginSettings.put(IrcBotGlobalConfig.class.getName()
+						+ ".ircEncoding", config.getIrcEncoding());
 				return null;
 			}
 		});

--- a/src/main/java/com/github/j5ik2o/jiraircbot/IssueListener.java
+++ b/src/main/java/com/github/j5ik2o/jiraircbot/IssueListener.java
@@ -3,6 +3,7 @@ package com.github.j5ik2o.jiraircbot;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 import org.jibble.pircbot.Colors;
@@ -44,8 +45,8 @@ public class IssueListener implements InitializingBean, DisposableBean {
 
 	private final PircBot pircBot = new PircBot() {
 		{
-			// setName("jira-irc-bot-" + UUID.randomUUID().toString());
-			setName("jira-irc-bot");
+			setName("jira-irc-bot-" + UUID.randomUUID().toString());
+//			setName("jira-irc-bot");
 		}
 	};
 
@@ -434,6 +435,11 @@ public class IssueListener implements InitializingBean, DisposableBean {
 		return null;
 	}
 
+	private String getIrcEncoding(PluginSettings settings) {
+		return (String) settings.get(IrcBotGlobalConfig.class.getName()
+				+ ".ircEncoding");
+	}
+
 	private void autoConnect() throws NickAlreadyInUseException, IOException,
 			IrcException {
 		if (pircBot.isConnected()) {
@@ -444,6 +450,12 @@ public class IssueListener implements InitializingBean, DisposableBean {
 		LOGGER.debug("irc server name = " + ircServerName);
 		Integer ircServerPort = getIrcServerPort(settings);
 		LOGGER.debug("irc server port = " + ircServerPort);
+		String ircEncoding = getIrcEncoding(settings);
+		if (ircEncoding == null || ircEncoding.length() == 0) {
+			ircEncoding = "UTF-8";
+		}
+		LOGGER.debug("irc encoding = " + ircEncoding);
+		pircBot.setEncoding(ircEncoding);
 		if (ircServerPort != null && ircServerPort.intValue() != 0) {
 			pircBot.connect(ircServerName, ircServerPort.intValue());
 		} else {

--- a/src/main/java/com/github/j5ik2o/jiraircbot/IssueListener.java
+++ b/src/main/java/com/github/j5ik2o/jiraircbot/IssueListener.java
@@ -45,8 +45,8 @@ public class IssueListener implements InitializingBean, DisposableBean {
 
 	private final PircBot pircBot = new PircBot() {
 		{
-			setName("jira-irc-bot-" + UUID.randomUUID().toString());
-//			setName("jira-irc-bot");
+//			setName("jira-irc-bot-" + UUID.randomUUID().toString());
+			setName("jira-irc-bot");
 		}
 	};
 

--- a/src/main/resources/admin.js
+++ b/src/main/resources/admin.js
@@ -13,6 +13,7 @@ AJS.toInit(function() {
                 }
                 AJS.$("#ircServerName").attr("value", config.ircServerName);
                 AJS.$("#ircServerPort").attr("value", config.ircServerPort);
+                AJS.$("#ircEncoding").attr("value", config.ircEncoding);
             }
         });
     }
@@ -23,7 +24,7 @@ AJS.toInit(function() {
             url: baseUrl + "/rest/jira-irc-bot/1.0/globalConfig",
             type: "PUT",
             contentType: "application/json",
-            data: '{ "enable": "' + enable + '", "ircServerName": "' + AJS.$("#ircServerName").attr("value") + '", "ircServerPort": ' +  AJS.$("#ircServerPort").attr("value") + ' }',
+            data: '{ "enable": "' + enable + '", "ircServerName": "' + AJS.$("#ircServerName").attr("value") + '", "ircServerPort": ' +  AJS.$("#ircServerPort").attr("value") + ', "ircEncoding": "' + AJS.$("#ircEncoding").attr("value") + '" }',
             processData: false
         });
     }

--- a/src/main/resources/admin.js
+++ b/src/main/resources/admin.js
@@ -18,11 +18,12 @@ AJS.toInit(function() {
     }
     
     function updateConfig() {
+    	var enable = AJS.$("#enable").attr("checked") == "checked" ? "true" : "false";
         AJS.$.ajax({
             url: baseUrl + "/rest/jira-irc-bot/1.0/globalConfig",
             type: "PUT",
             contentType: "application/json",
-            data: '{ "enable": "' + AJS.$("#enable").attr("checked") + '", "ircServerName": "' + AJS.$("#ircServerName").attr("value") + '", "ircServerPort": ' +  AJS.$("#ircServerPort").attr("value") + ' }',
+            data: '{ "enable": "' + enable + '", "ircServerName": "' + AJS.$("#ircServerName").attr("value") + '", "ircServerPort": ' +  AJS.$("#ircServerPort").attr("value") + ' }',
             processData: false
         });
     }

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -21,6 +21,10 @@
         <input type="text" id="ircServerPort" name="ircServerPort" class="text">
       </div>
       <div>
+        <label for="ircEncoding">$i18n.getText("jiraircbot.admin.ircEncoding.label")</label>
+        <input type="text" id="ircEncoding" name="ircEncoding" class="text">
+      </div>
+      <div>
         <input id="submit" type="submit" value="$i18n.getText("jiraircbot.admin.save.label")" class="button">
       </div>
     </form>

--- a/src/main/resources/com/github/j5ik2o/jiraircbot/i18n.properties
+++ b/src/main/resources/com/github/j5ik2o/jiraircbot/i18n.properties
@@ -2,6 +2,7 @@ jiraircbot.admin.label=IRCBot Global Settings
 jiraircbot.admin.enable.label=Enable
 jiraircbot.admin.ircServerName.label=IRC Server Name
 jiraircbot.admin.ircServerPort.label=IRC Server Port
+jiraircbot.admin.ircEncoding.label=Encoding
 jiraircbot.admin.save.label=Save
 jiraircbot.project.label=IRCBot Channel Settings
 jiraircbot.project.enable.label=Enable

--- a/src/main/resources/com/github/j5ik2o/jiraircbot/i18n_ja_JP.properties
+++ b/src/main/resources/com/github/j5ik2o/jiraircbot/i18n_ja_JP.properties
@@ -2,6 +2,7 @@ jiraircbot.admin.label=IRCBot \u30b0\u30ed\u30fc\u30d0\u30eb\u8a2d\u5b9a
 jiraircbot.admin.enable.label=\u6709\u52b9
 jiraircbot.admin.ircServerName.label=IRC\u30b5\u30fc\u30d0\u540d
 jiraircbot.admin.ircServerPort.label=IRC\u30b5\u30fc\u30d0\u30dd\u30fc\u30c8
+jiraircbot.admin.ircEncoding.label=\u30a8\u30f3\u30b3\u30fc\u30c7\u30a3\u30f3\u30b0
 jiraircbot.admin.save.label=\u4fdd\u5b58
 jiraircbot.project.label=IRCBot \u30c1\u30e3\u30f3\u30cd\u30eb\u8a2d\u5b9a
 jiraircbot.project.enable.label=\u6709\u52b9

--- a/src/main/resources/project.js
+++ b/src/main/resources/project.js
@@ -41,12 +41,14 @@ AJS.toInit(function() {
     }
     
     function updateConfig() {
+    	var enable = AJS.$("#enable").attr("checked") == "checked" ? "true" : "false";
+    	var notice = AJS.$("#notice").attr("checked") == "checked" ? "true" : "false"; 
         AJS.$.ajax({
             url: baseUrl + "/rest/jira-irc-bot/1.0/channelConfig/" + projectId,
             type: "PUT",
             contentType: "application/json",
-            data: '{ "enable": "' + AJS.$("#enable").attr("checked") +
-                '", "notice": "' + AJS.$("#notice").attr("checked") +
+            data: '{ "enable": "' + enable +
+                '", "notice": "' + notice +
                 '", "channelName": "' +  AJS.$("#channelName").attr("value") + '" }',
             processData: false
         });


### PR DESCRIPTION
1. JIRA5.2上でIRC Botの設定が保存できなくなっていたのを修正した
2. グローバル設定でIRCのエンコーディング設定を可能にした
